### PR TITLE
fix(engine): hot-loader respects --spec filter (fixes #630)

### DIFF
--- a/packages/agentfox/agentfox/engine/hot_load.py
+++ b/packages/agentfox/agentfox/engine/hot_load.py
@@ -228,15 +228,22 @@ async def discover_new_specs_gated(
     *,
     integration_branch: str = "main",
     db_conn: duckdb.DuckDBPyConnection | None = None,
+    filtered_spec: str | None = None,
 ) -> list[SpecInfo]:
     """Discover new specs that pass all four gates.
 
     Pipeline:
+    0. Pre-filter: if ``filtered_spec`` is set, reject specs not matching.
     1. Filesystem discovery (existing ``discover_new_specs``).
     2. Gate 1: git-tracked on the integration branch.
     3. Gate 2: all 5 required files present and non-empty.
     4. Gate 3: no lint errors from validator.
     5. Gate 4: not already fully implemented (tasks.json + plan state).
+
+    When ``filtered_spec`` is set (from ``af plan --spec``), only that
+    spec is considered as a candidate.  All other specs are rejected
+    before gate evaluation, preventing the hot-loader from re-introducing
+    unrelated completed specs (issue #630).
 
     Returns only specs that pass all gates.  Skipped specs are
     re-evaluated at the next barrier with a clean slate (51-REQ-7.2).
@@ -249,6 +256,8 @@ async def discover_new_specs_gated(
             (tasks-complete gate).  When None, the plan node check is
             skipped (gate degrades gracefully — specs are never skipped
             based on plan state alone).
+        filtered_spec: When set, only this spec name is eligible for
+            hot-loading.  All others are rejected before gate evaluation.
 
     Requirements: 51-REQ-4.1, 51-REQ-5.1, 51-REQ-6.1, 51-REQ-7.1,
                   51-REQ-7.2, 51-REQ-7.3
@@ -256,6 +265,20 @@ async def discover_new_specs_gated(
     candidates = discover_new_specs(specs_dir, known_specs)
     if not candidates:
         return []
+
+    # Pre-filter: respect --spec filter from plan metadata (issue #630)
+    if filtered_spec:
+        before = len(candidates)
+        candidates = [s for s in candidates if s.name == filtered_spec]
+        skipped = before - len(candidates)
+        if skipped:
+            logger.debug(
+                "Filtered out %d spec(s) not matching --spec %s",
+                skipped,
+                filtered_spec,
+            )
+        if not candidates:
+            return []
 
     accepted: list[SpecInfo] = []
     for spec in candidates:
@@ -484,9 +507,12 @@ async def hot_load_into_graph(
 
     known_specs = {n.spec_name for n in graph.nodes.values()}
     gated_specs = await discover_new_specs_gated(
-        specs_dir, known_specs, repo_root,
+        specs_dir,
+        known_specs,
+        repo_root,
         integration_branch=integration_branch,
         db_conn=knowledge_db_conn,
+        filtered_spec=graph.metadata.filtered_spec,
     )
 
     if not gated_specs:

--- a/packages/agentfox/tests/unit/engine/test_hot_load_gates.py
+++ b/packages/agentfox/tests/unit/engine/test_hot_load_gates.py
@@ -400,7 +400,10 @@ class TestFullGatePipeline:
             ),
         ):
             result = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path, integration_branch="main",
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
             )
 
         assert len(result) == 1
@@ -459,7 +462,10 @@ class TestSkippedSpecReEvaluation:
         ):
             # Barrier N: spec is incomplete
             result_1 = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path, integration_branch="main",
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
             )
             assert result_1 == []
 
@@ -468,7 +474,10 @@ class TestSkippedSpecReEvaluation:
 
             # Barrier N+1: spec now passes
             result_2 = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path, integration_branch="main",
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
             )
             assert len(result_2) == 1
             assert result_2[0].name == "42_feature"
@@ -726,8 +735,11 @@ class TestTasksCompleteGatePipeline:
             caplog.at_level(logging.INFO, logger="agentfox.engine.hot_load"),
         ):
             result = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path,
-                integration_branch="main", db_conn=conn,
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
+                db_conn=conn,
             )
 
         assert result == []
@@ -770,8 +782,11 @@ class TestTasksCompleteGatePipeline:
             patch("agentfox.engine.hot_load.are_all_tasks_done", return_value=True),
         ):
             result = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path,
-                integration_branch="main", db_conn=conn,
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
+                db_conn=conn,
             )
 
         assert len(result) == 1
@@ -814,8 +829,11 @@ class TestTasksCompleteGatePipeline:
             patch("agentfox.engine.hot_load.are_all_tasks_done", return_value=False),
         ):
             result = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path,
-                integration_branch="main", db_conn=conn,
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
+                db_conn=conn,
             )
 
         assert len(result) == 1
@@ -853,7 +871,152 @@ class TestTasksCompleteGatePipeline:
         ):
             # No db_conn argument — backward compatible
             result = await discover_new_specs_gated(
-                specs_dir, known_specs=set(), repo_root=tmp_path, integration_branch="main",
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                integration_branch="main",
             )
 
         assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #630: hot-loader respects --spec filter (filtered_spec parameter)
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredSpecRespected:
+    """Issue #630: discover_new_specs_gated rejects specs not matching filtered_spec."""
+
+    @pytest.mark.asyncio
+    async def test_unrelated_spec_rejected_when_filter_set(self, tmp_path: Path) -> None:
+        """With filtered_spec='09_collision', spec '01_models' is rejected."""
+        from agentfox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        unrelated = specs_dir / "01_models"
+        _create_spec_files(unrelated)
+
+        mock_spec = SpecInfo(
+            name="01_models",
+            prefix=1,
+            path=unrelated,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        with patch("agentfox.engine.hot_load.discover_new_specs", return_value=[mock_spec]):
+            result = await discover_new_specs_gated(
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                filtered_spec="09_collision",
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_matching_spec_passes_filter(self, tmp_path: Path) -> None:
+        """With filtered_spec='09_collision', spec '09_collision' proceeds to gates."""
+        from agentfox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        target = specs_dir / "09_collision"
+        _create_spec_files(target)
+
+        mock_spec = SpecInfo(
+            name="09_collision",
+            prefix=9,
+            path=target,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(*args, **kwargs):
+            return True
+
+        with (
+            patch("agentfox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agentfox.engine.hot_load.is_spec_tracked_on_branch", side_effect=mock_is_tracked),
+            patch("agentfox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.lint_spec_gate", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.are_all_tasks_done", return_value=False),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                filtered_spec="09_collision",
+            )
+
+        assert len(result) == 1
+        assert result[0].name == "09_collision"
+
+    @pytest.mark.asyncio
+    async def test_no_filter_allows_all_specs(self, tmp_path: Path) -> None:
+        """With filtered_spec=None, all specs proceed to gates."""
+        from agentfox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        _create_spec_files(specs_dir / "01_models")
+        _create_spec_files(specs_dir / "06_split")
+
+        mock_specs = [
+            SpecInfo(name="01_models", prefix=1, path=specs_dir / "01_models", has_tasks=True, has_prd=True),
+            SpecInfo(name="06_split", prefix=6, path=specs_dir / "06_split", has_tasks=True, has_prd=True),
+        ]
+
+        async def mock_is_tracked(*args, **kwargs):
+            return True
+
+        with (
+            patch("agentfox.engine.hot_load.discover_new_specs", return_value=mock_specs),
+            patch("agentfox.engine.hot_load.is_spec_tracked_on_branch", side_effect=mock_is_tracked),
+            patch("agentfox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.lint_spec_gate", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.are_all_tasks_done", return_value=False),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                filtered_spec=None,
+            )
+
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_multiple_candidates_only_match_survives(self, tmp_path: Path) -> None:
+        """With filtered_spec set, only the matching spec survives from multiple candidates."""
+        from agentfox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        _create_spec_files(specs_dir / "01_models")
+        _create_spec_files(specs_dir / "06_split")
+        _create_spec_files(specs_dir / "09_collision")
+
+        mock_specs = [
+            SpecInfo(name="01_models", prefix=1, path=specs_dir / "01_models", has_tasks=True, has_prd=True),
+            SpecInfo(name="06_split", prefix=6, path=specs_dir / "06_split", has_tasks=True, has_prd=True),
+            SpecInfo(name="09_collision", prefix=9, path=specs_dir / "09_collision", has_tasks=True, has_prd=True),
+        ]
+
+        async def mock_is_tracked(*args, **kwargs):
+            return True
+
+        with (
+            patch("agentfox.engine.hot_load.discover_new_specs", return_value=mock_specs),
+            patch("agentfox.engine.hot_load.is_spec_tracked_on_branch", side_effect=mock_is_tracked),
+            patch("agentfox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.lint_spec_gate", return_value=(True, [])),
+            patch("agentfox.engine.hot_load.are_all_tasks_done", return_value=False),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir,
+                known_specs=set(),
+                repo_root=tmp_path,
+                filtered_spec="09_collision",
+            )
+
+        assert len(result) == 1
+        assert result[0].name == "09_collision"


### PR DESCRIPTION
## Summary

- Added `filtered_spec` parameter to `discover_new_specs_gated()` that rejects non-matching specs before gate evaluation
- `hot_load_into_graph()` now passes `graph.metadata.filtered_spec` to the gated discovery function
- Prevents the hot-loader from re-introducing completed specs when `af plan --spec X` was used

Closes #630

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/engine/hot_load.py` | `filtered_spec` pre-filter in `discover_new_specs_gated()`, plumbed from `hot_load_into_graph()` |
| `packages/agentfox/tests/unit/engine/test_hot_load_gates.py` | 4 new tests for filtered_spec behavior |

## Tests

- `test_unrelated_spec_rejected_when_filter_set`
- `test_matching_spec_passes_filter`
- `test_no_filter_allows_all_specs`
- `test_multiple_candidates_only_match_survives`

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*