### PR TITLE
feat(engine): assign af:implemented label on spec completion (fixes #636)

### DIFF
--- a/packages/agentfox/agentfox/engine/engine.py
+++ b/packages/agentfox/agentfox/engine/engine.py
@@ -1082,5 +1082,25 @@ async def post_issue_summaries(
                 spec_name,
                 exc_info=True,
             )
+            continue
+
+        # Issue #636: assign af:implemented label after successful comment
+        try:
+            from agentfox.platform.labels import LABEL_IMPLEMENTED
+
+            await platform.assign_label(source_issue.issue_number, LABEL_IMPLEMENTED)
+            logger.info(
+                "Assigned '%s' label to issue #%d for spec '%s'",
+                LABEL_IMPLEMENTED,
+                source_issue.issue_number,
+                spec_name,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to assign '%s' label for spec '%s'",
+                "af:implemented",
+                spec_name,
+                exc_info=True,
+            )
 
     return posted

--- a/packages/agentfox/agentfox/platform/labels.py
+++ b/packages/agentfox/agentfox/platform/labels.py
@@ -34,6 +34,9 @@ LABEL_IGNORE: str = "af:ignore"
 #: Gray hex color for the af:ignore label.
 LABEL_IGNORE_COLOR: str = "999999"
 
+#: Applied when all task groups for a spec are completed — awaiting verification.
+LABEL_IMPLEMENTED: str = "af:implemented"
+
 
 # ---------------------------------------------------------------------------
 # Label metadata for idempotent creation
@@ -75,5 +78,10 @@ REQUIRED_LABELS: list[LabelSpec] = [
         name=LABEL_IGNORE,
         color=LABEL_IGNORE_COLOR,
         description="Hunt findings marked as not-an-issue by the user",
+    ),
+    LabelSpec(
+        name=LABEL_IMPLEMENTED,
+        color="0969da",
+        description="Spec implementation complete — awaiting manual verification",
     ),
 ]

--- a/packages/agentfox/tests/unit/engine/test_issue_summary.py
+++ b/packages/agentfox/tests/unit/engine/test_issue_summary.py
@@ -265,6 +265,7 @@ class TestPostIssueSummaries:
         platform = MagicMock()
         platform.forge_type = forge_type
         platform.add_issue_comment = AsyncMock()
+        platform.assign_label = AsyncMock()
         return platform
 
     def _mock_git_sha(self, sha: str = "abc123") -> MagicMock:
@@ -390,6 +391,78 @@ class TestPostIssueSummaries:
         assert spec_name not in posted
         # Warning must be logged
         assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_assigns_implemented_label_on_success(self, tmp_path: Path) -> None:
+        """Issue #636: assign_label called with af:implemented after successful post."""
+        from agentfox.engine.engine import post_issue_summaries
+
+        spec_name = "108_my_spec"
+        specs_dir = tmp_path / "specs"
+        self._make_spec_dir(specs_dir, spec_name, "https://github.com/owner/repo/issues/42")
+
+        platform = self._make_mock_platform(forge_type="github")
+
+        with patch("subprocess.run", return_value=self._mock_git_sha("abc123")):
+            posted = await post_issue_summaries(
+                platform=platform,
+                specs_dir=specs_dir,
+                completed_specs={spec_name},
+                already_posted=set(),
+                repo_root=tmp_path,
+            )
+
+        assert spec_name in posted
+        platform.assign_label.assert_called_once_with(42, "af:implemented")
+
+    @pytest.mark.asyncio
+    async def test_label_failure_does_not_block_posting(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Issue #636: assign_label failure is caught; spec still in posted set."""
+        from agentfox.engine.engine import post_issue_summaries
+
+        spec_name = "108_my_spec"
+        specs_dir = tmp_path / "specs"
+        self._make_spec_dir(specs_dir, spec_name, "https://github.com/owner/repo/issues/42")
+
+        platform = self._make_mock_platform(forge_type="github")
+        platform.assign_label = AsyncMock(side_effect=RuntimeError("label API error"))
+
+        with caplog.at_level(logging.WARNING), patch("subprocess.run", return_value=self._mock_git_sha("abc123")):
+            posted = await post_issue_summaries(
+                platform=platform,
+                specs_dir=specs_dir,
+                completed_specs={spec_name},
+                already_posted=set(),
+                repo_root=tmp_path,
+            )
+
+        assert spec_name in posted
+        assert any("af:implemented" in r.message for r in caplog.records if r.levelno >= logging.WARNING)
+
+    @pytest.mark.asyncio
+    async def test_label_not_assigned_when_comment_fails(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Issue #636: assign_label is NOT called when add_issue_comment fails."""
+        from agentfox.engine.engine import post_issue_summaries
+
+        spec_name = "108_my_spec"
+        specs_dir = tmp_path / "specs"
+        self._make_spec_dir(specs_dir, spec_name, "https://github.com/owner/repo/issues/42")
+
+        platform = self._make_mock_platform(forge_type="github")
+        platform.add_issue_comment = AsyncMock(side_effect=RuntimeError("network error"))
+
+        with caplog.at_level(logging.WARNING), patch("subprocess.run", return_value=self._mock_git_sha("abc123")):
+            await post_issue_summaries(
+                platform=platform,
+                specs_dir=specs_dir,
+                completed_specs={spec_name},
+                already_posted=set(),
+                repo_root=tmp_path,
+            )
+
+        platform.assign_label.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `LABEL_IMPLEMENTED = "af:implemented"` constant and `LabelSpec` to `labels.py`
- `post_issue_summaries()` now calls `platform.assign_label()` after successful comment posting
- Label assignment failures are caught and logged as warnings — spec still recorded as posted
- When commenting fails, `continue` skips label assignment entirely

Closes #636

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/platform/labels.py` | Added `LABEL_IMPLEMENTED` and `LabelSpec` |
| `packages/agentfox/agentfox/engine/engine.py` | Label assignment after comment posting |
| `packages/agentfox/tests/unit/engine/test_issue_summary.py` | Updated fixture + 3 new tests |

## Tests

- `test_assigns_implemented_label_on_success`
- `test_label_failure_does_not_block_posting`
- `test_label_not_assigned_when_comment_fails`

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*