### PR TITLE
fix(session): record per-tool errors via PostToolUseFailure SDK hook (fixes #672)

### DIFF
--- a/packages/agentfox/agentfox/session/backends/claude.py
+++ b/packages/agentfox/agentfox/session/backends/claude.py
@@ -80,6 +80,7 @@ class ClaudeBackend:
         cwd: str,
         permission_callback: PermissionCallback | None = None,
         activity_callback: ActivityCallback | None = None,
+        tool_error_callback: Any | None = None,
         node_id: str = "",
         archetype: str | None = None,
         max_turns: int | None = None,
@@ -140,17 +141,23 @@ class ClaudeBackend:
             except TypeError as exc:
                 logger.warning("SDK does not support 'thinking' parameter, omitting: %s", exc)
 
-        # Register a Notification hook when an activity_callback is provided.
-        # The hook converts SDK NotificationHookInput to ActivityEvent and
-        # forwards it to the callback. (AC-1, AC-2, AC-7 — issue #320)
+        # Register hooks for Notification (activity tracking) and
+        # PostToolUseFailure (tool error tracking).
+        hooks: dict[str, list[HookMatcher]] = {}
         if activity_callback is not None:
-            options.hooks = {
-                "Notification": [
-                    HookMatcher(
-                        hooks=[_build_notification_hook(activity_callback, node_id=node_id, archetype=archetype)],
-                    )
-                ]
-            }
+            hooks["Notification"] = [
+                HookMatcher(
+                    hooks=[_build_notification_hook(activity_callback, node_id=node_id, archetype=archetype)],
+                )
+            ]
+        if tool_error_callback is not None:
+            hooks["PostToolUseFailure"] = [
+                HookMatcher(
+                    hooks=[_build_tool_error_hook(tool_error_callback)],
+                )
+            ]
+        if hooks:
+            options.hooks = hooks
 
         # Transport-layer retry loop (AC-1 through AC-4).
         # Transient errors (connection failure or missing ResultMessage) are
@@ -409,6 +416,37 @@ def _build_notification_hook(
         return {}
 
     return _notification_hook
+
+
+def _build_tool_error_hook(callback: Any) -> Any:
+    """Return an async PostToolUseFailure hook that records tool errors.
+
+    ``PostToolUseFailureHookInput`` is a TypedDict with keys:
+    ``tool_name`` (str), ``error`` (str), ``tool_use_id`` (str).
+
+    Calls ``callback(tool_name, error)`` for each failure.
+    """
+
+    async def _tool_error_hook(
+        hook_input: Any,
+        tool_use_id: Any,  # noqa: ARG001
+        context: Any,  # noqa: ARG001
+    ) -> dict[str, Any]:
+        if isinstance(hook_input, dict):
+            tool_name = hook_input.get("tool_name", "unknown")
+            error = hook_input.get("error", "")
+        else:
+            tool_name = getattr(hook_input, "tool_name", "unknown")
+            error = getattr(hook_input, "error", "")
+
+        try:
+            callback(tool_name, error)
+        except Exception:
+            logger.debug("Tool error callback raised; ignoring")
+
+        return {}
+
+    return _tool_error_hook
 
 
 def _coerce_int(value: Any) -> int:

--- a/packages/agentfox/agentfox/session/session.py
+++ b/packages/agentfox/agentfox/session/session.py
@@ -236,6 +236,16 @@ async def _execute_query(
             task_prompt=task_prompt,
         )
 
+    def _on_tool_error(tool_name: str, error_message: str) -> None:
+        if sink_dispatcher is not None:
+            sink_dispatcher.record_tool_error(ToolError(session_id=run_id, node_id=node_id, tool_name=tool_name))
+            sink_dispatcher.record_tool_error_trace(
+                run_id=run_id,
+                node_id=node_id,
+                tool_name=tool_name,
+                error_message=error_message,
+            )
+
     async for message in backend.execute(  # type: ignore[attr-defined]
         task_prompt,
         system_prompt=system_prompt,
@@ -243,6 +253,7 @@ async def _execute_query(
         cwd=cwd,
         permission_callback=_permission_callback,
         activity_callback=activity_callback,
+        tool_error_callback=_on_tool_error if sink_dispatcher else None,
         node_id=node_id,
         archetype=archetype,
         max_turns=max_turns,

--- a/packages/agentfox/tests/integration/test_agent_trace_smoke.py
+++ b/packages/agentfox/tests/integration/test_agent_trace_smoke.py
@@ -59,6 +59,7 @@ class MockBackend:
         max_turns: int | None = None,
         max_budget_usd: float | None = None,
         thinking: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> AsyncIterator[AgentMessage]:
         for msg in self._messages:
             yield msg

--- a/packages/agentfox/tests/unit/session/test_runner.py
+++ b/packages/agentfox/tests/unit/session/test_runner.py
@@ -14,6 +14,7 @@ Requirements: 03-REQ-3.1 through 03-REQ-3.E2, 03-REQ-6.1, 03-REQ-6.2,
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -68,6 +69,7 @@ class MockBackend:
         max_turns: int | None = None,
         max_budget_usd: float | None = None,
         thinking: dict | None = None,
+        **kwargs: Any,
     ) -> AsyncIterator[AgentMessage]:
         self.last_prompt = prompt
         self.last_system_prompt = system_prompt


### PR DESCRIPTION
## Summary

The `tool_errors` table was always empty because `record_tool_error()` only fired on session-level `is_error`, not on individual tool failures. The Claude Agent SDK's `PostToolUseFailure` hook fires for each tool invocation failure, providing `tool_name` and `error` — exactly what's needed.

Closes #672

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/session/backends/claude.py` | `PostToolUseFailure` hook + `_build_tool_error_hook()` |
| `packages/agentfox/agentfox/session/session.py` | `_on_tool_error` closure, passed as `tool_error_callback` |
| Test mock backends (2 files) | Added `**kwargs` for forward compatibility |

## Verification

- All existing tests pass: ✅ (5857)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*